### PR TITLE
fixed teleport with 3 or more players in the same time

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1,16 +1,9 @@
+local TeleportationStates = {}
+
 RegisterNetEvent('NorthYankton:server:playerRequestTeleport', function()
-    local enabled = GetPlayerRoutingBucket(source) == Config.RoutingBucket
-
-    ToggleNorthYankton(source, not enabled);
+    local player = source
+    TeleportationStates[player] = not (TeleportationStates[player] or false)
+    local bucket = TeleportationStates[player] and 1337 or 0
+    SetPlayerRoutingBucket(player, bucket)
+    TriggerClientEvent('NorthYankton:client:routingBucketChanged', player, bucket)
 end)
-
-function ToggleNorthYankton(source, enabled)
-    -- Set the player in the North Yankton routing bucket
-    local bucket = Config.RoutingBucket
-    SetPlayerRoutingBucket(source, enabled and bucket or 0)
-
-    -- Enable North Yankton on the client
-    TriggerClientEvent('NorthYankton:client:routingBucketChanged', source, enabled)
-end
-
-exports('ToggleNorthYankton', ToggleNorthYankton)


### PR DESCRIPTION
The previous code did not function correctly when 3 or more players attempted to teleport to North Yankton simultaneously. The current code rectifies this issue.