### PR TITLE
break out of loop to disable double teleport

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -145,6 +145,7 @@ CreateThread(function()
                                 SetPedCoordsKeepVehicle(ped, calcTo)
                                 activateTeleport = false
                                 inZone = false
+				break	
                             end
                         end
                         


### PR DESCRIPTION
The bug: With the default teleport locations, if the UseTeleportDistance is >1, when pressing the button to teleport from location 1 the player's location is set next to location 2's teleporter. The code then checks whether the player is next to location 2's teleporter, and since they are, teleports them to the taxi pickup outside LSIA.